### PR TITLE
Add devcert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ yarn.lock
 SERVER.md
 proxy/cert.pem
 proxy/key.pem
+private/cert.pem
+private/key.pem

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Made with _kindness_ in California. 🏄
     * https://yarnpkg.com/en/docs/install
 2. Install h2o Proxy (to allow for local h2 and h2 push)
     * Depends on your OS. Tend to use 'brew' on MacOS -- 'brew update; brew install h2o'
-    * Put some self-signed certs in the 'proxy' folder (http://stackoverflow.com/questions/10175812/how-to-create-a-self-signed-certificate-with-openssl)
+    * Https certs will be installed automatically when you do yarn start.
 3. Install Brotli and Zopfli CLI
     * Again, depends on your OS. Typically just use 'brew', 'brew update; brew install brotli; brew install zopfli'
     * https://github.com/google/brotli
@@ -22,8 +22,8 @@ Made with _kindness_ in California. 🏄
 4. Install Yarn Dependencies
     * yarn install
 5. Run Locally
-    * yarn run start (chrome only)
-    * yarn run bundle:prod; yarn run start (all browsers)
+    * yarn start (chrome only)
+    * yarn bundle:prod; yarn run start (all browsers)
 6. Access using your favorite browser
     * https://localhost:5443
 

--- a/config/gen-certs.js
+++ b/config/gen-certs.js
@@ -4,7 +4,7 @@ const getDevelopmentCertificate = require("devcert-with-localhost").default;
 const fs = require("fs");
 const path = require("path");
 
-const PRIVATE_FOLDER_PATH = path.join(__dirname, "..", "private");
+const PRIVATE_FOLDER_PATH = path.join(__dirname, "..", "proxy");
 const CERT_KEY_PATH = path.join(PRIVATE_FOLDER_PATH, "key.pem");
 const CERT_PATH = path.join(PRIVATE_FOLDER_PATH, "cert.pem");
 

--- a/config/gen-certs.js
+++ b/config/gen-certs.js
@@ -1,0 +1,49 @@
+const chalk = require("chalk");
+const getDevelopmentCertificate = require("devcert-with-localhost").default;
+
+const fs = require("fs");
+const path = require("path");
+
+const PRIVATE_FOLDER_PATH = path.join(__dirname, "..", "private");
+const CERT_KEY_PATH = path.join(PRIVATE_FOLDER_PATH, "key.pem");
+const CERT_PATH = path.join(PRIVATE_FOLDER_PATH, "cert.pem");
+
+if (fs.existsSync(CERT_PATH)) {
+  process.stdout.write(
+    chalk.yellow.bold("📄  Existing certificate found.") +
+      chalk.dim(" It will be replaced with a new one\n")
+  );
+  fs.unlinkSync(CERT_PATH);
+}
+if (fs.existsSync(CERT_KEY_PATH)) {
+  process.stdout.write(
+    chalk.yellow.bold("🔑  Existing private key found.") +
+      chalk.dim(" It will be replaced with a new one\n")
+  );
+  fs.unlinkSync(CERT_KEY_PATH);
+}
+
+process.stdout.write(
+  chalk.blue(
+    "🔐  Attempting to automatically generate X.509 certificate and private key\n"
+  )
+);
+getDevelopmentCertificate("react-hn", { installCertutil: true })
+  .then(({ key, cert }) => {
+    process.stdout.write(chalk.green.bold("   ↪ ✅  Success!\n"));
+
+    fs.writeFileSync(CERT_PATH, cert);
+    fs.writeFileSync(CERT_KEY_PATH, key);
+
+    fs.chmodSync(CERT_PATH, "0400");
+    fs.chmodSync(CERT_KEY_PATH, "0400");
+    process.exit(0);
+  })
+  .catch(err => {
+    process.stderr.write(
+      chalk.red(
+        `   ↪ There was a problem automatically generating X.509 certificates for HTTPS! You may want to consult the "Manually Generating Certificates" section of the README\n${err}\n`
+      )
+    );
+    process.exit(1);
+  });

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bundle:server": "BABEL_ENV=server node_modules/.bin/webpack --config config/webpack.server.js --json > dist/server/webpack.json",
     "bundle:prod": "NODE_ENV=production yarn run bundle:all;",
     "test:h2o": "cd dist/server && h2o -t -c h2o.config.yaml",
-    "prepcerts": "node ./config/gen-certs.js && rm -rf proxy/*.pem && cp private/*.pem proxy/"
+    "prepcerts": " rm -rf proxy/*.pem && node ./config/gen-certs.js"
   },
   "dependencies": {
     "bunyan": "^1.8.12",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Kristofer Baxter",
   "license": "MIT",
   "scripts": {
-    "start": "node_modules/.bin/nodemon -e js,css --config nodemon.config.json --exec 'yarn' start:node:dev-after-bundle",
+    "start": "yarn prepcerts && node_modules/.bin/nodemon -e js,css --config nodemon.config.json --exec 'yarn' start:node:dev-after-bundle",
     "start:node": "node dist/server/restify.server.js | ./node_modules/.bin/bunyan",
     "start:node:dev-after-bundle": "yarn run bundle:dev; yarn run start:node",
     "start:h2o": "cd dist/server && h2o -c h2o.config.yaml",
@@ -19,10 +19,12 @@
     "bundle:fallback": "BABEL_ENV=fallback node_modules/.bin/webpack --config config/webpack.fallback.js --json > dist/fallback/webpack.json",
     "bundle:server": "BABEL_ENV=server node_modules/.bin/webpack --config config/webpack.server.js --json > dist/server/webpack.json",
     "bundle:prod": "NODE_ENV=production yarn run bundle:all;",
-    "test:h2o": "cd dist/server && h2o -t -c h2o.config.yaml"
+    "test:h2o": "cd dist/server && h2o -t -c h2o.config.yaml",
+    "prepcerts": "node ./config/gen-certs.js && rm -rf proxy/*.pem && cp private/*.pem proxy/"
   },
   "dependencies": {
     "bunyan": "^1.8.12",
+    "devcert-with-localhost": "^0.3.3",
     "forever": "^0.15.3",
     "history": "^4.7.2",
     "iltorb": "^1.2.1",
@@ -52,9 +54,11 @@
     "brotli-webpack-plugin": "^0.4.1",
     "browserslist": "^2.4.0",
     "bundle-loader": "^0.5.5",
+    "chalk": "^2.3.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.28.0",
     "cssnano": "^3.10.0",
+    "eslint": "^4.14.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "nodemon": "^1.11.0",
     "object.values": "^1.0.4",


### PR DESCRIPTION
I have added a package called `devcert`. Which creates ssl certs on the fly. All you have to do is, while you run the app for the first time, it will prompt you for a password. Enter your system password and voila. You will have certs in your proxy folder. 